### PR TITLE
Add Persistence model

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,4 +2,5 @@ use Mix.Config
 
 config :daisy,
   reader: Daisy.Examples.Kitten.Reader,
-  runner: Daisy.Examples.Kitten.Runner
+  runner: Daisy.Examples.Kitten.Runner,
+  ipfs_key: "miner"

--- a/lib/daisy.ex
+++ b/lib/daisy.ex
@@ -5,5 +5,6 @@ defmodule Daisy do
 
   def get_runner(), do: Application.get_env(:daisy, :runner)
   def get_reader(), do: Application.get_env(:daisy, :reader)
+  def get_ipfs_key(), do: Application.get_env(:daisy, :ipfs_key)
 
 end

--- a/lib/daisy/api/router.ex
+++ b/lib/daisy/api/router.ex
@@ -22,7 +22,7 @@ defmodule Daisy.API.Router do
 
     _result_transaction = Daisy.Minter.add_transaction(Daisy.Minter, transaction)
 
-    send_resp(conn, 200, %{"result" => "ok"} |> Poison.encode!)
+    send_resp(conn, 200, %{"result" => "ok"} |> Poison.encode! |> Kernel.<>("\n"))
   end
 
   get "/read/block/:block_hash/:function/*args" do
@@ -35,4 +35,5 @@ defmodule Daisy.API.Router do
   match _ do
     send_resp(conn, 404, "not found")
   end
+
 end

--- a/lib/daisy/application.ex
+++ b/lib/daisy/application.ex
@@ -8,7 +8,8 @@ defmodule Daisy.Application do
     children = [
       Plug.Adapters.Cowboy.child_spec(:http, Daisy.API.Router, [], [port: 2235]),
       Supervisor.Spec.worker(Daisy.Storage, [[name: Daisy.Storage]]),
-      Supervisor.Spec.worker(Daisy.Minter, [Daisy.Storage, :genesis, runner, reader, [mine: true, name: Daisy.Minter]]),
+      Supervisor.Spec.worker(Daisy.Persistence, [[name: Daisy.Persistence]]),
+      Supervisor.Spec.worker(Daisy.Minter, [Daisy.Storage, :resolve, runner, reader, [mine: true, name: Daisy.Minter]]),
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)

--- a/lib/daisy/block.ex
+++ b/lib/daisy/block.ex
@@ -182,10 +182,7 @@ defmodule Daisy.Block do
   @spec load_block(identifier(), block_hash) :: {:ok, Daisy.Data.Block.t} | {:error, any()}
   def load_block(storage_pid, block_hash) do
     with {:ok, values} <- Daisy.Storage.get_all(storage_pid, block_hash) do
-      block_values = values["block"]
-      block = @serializer.deserialize(block_values)
-
-      {:ok, block}
+      {:ok, @serializer.deserialize(values)}
     end
   end
 

--- a/lib/daisy/examples/kitten.ex
+++ b/lib/daisy/examples/kitten.ex
@@ -72,8 +72,10 @@ defmodule Daisy.Examples.Kitten do
 
     @spec read(String.t, [String.t], identifier(), Daisy.Storage.root_hash) :: {:ok, any()} | {:erorr, any()}
     def read("orphans", [], storage_pid, storage) do
-      with {:ok, orphan_json} <- Daisy.Storage.get(storage_pid, storage, "orphans") do
-        {:ok, Data.Orphan.deserialize(orphan_json)}
+      case Daisy.Storage.get(storage_pid, storage, "orphans") do
+        {:ok, orphan_json} -> {:ok, Data.Orphan.deserialize(orphan_json)}
+        :not_found -> {:ok, []}
+        error={:error, _error} -> error
       end
     end
 

--- a/lib/daisy/minter/publisher.ex
+++ b/lib/daisy/minter/publisher.ex
@@ -1,0 +1,81 @@
+defmodule Daisy.Publisher do
+  @moduledoc """
+
+  """
+  use GenServer
+  require Logger
+
+  @type state :: %{
+    minter_pid: identifier()
+  }
+
+  @interval 10_000
+  @mine_timeout 60_000
+
+  def start_link(minter_pid, opts \\ []) do
+    name = Keyword.get(opts, :name, nil)
+
+    gen_server_args = if name do
+      [name: name]
+    else
+      []
+    end
+
+    GenServer.start_link(__MODULE__, {minter_pid, opts}, gen_server_args)
+  end
+
+  @spec init({identifier(), identifier(), keyword()}) :: {:ok, state}
+  def init({minter_pid, opts}) do
+    mining_interval = Keyword.get(opts, :mining_interval, @interval)
+
+    Logger.info("[#{__MODULE__}] Mining every #{@interval/1000.0} seconds.")
+
+    queue_mining(mining_interval)
+
+    {:ok, %{
+      minter_pid: minter_pid
+    }}
+  end
+
+  ## Server
+
+  def handle_info({:mine_block, interval}, %{minter_pid: minter_pid}=state) do
+    Logger.debug(fn -> "[#{__MODULE__}] Requesting new block to publish from minter..." end)
+
+    # First, mine the block
+    case Daisy.Minter.mint_current_block(minter_pid) do
+      {:ok, final_block_hash} ->
+        Logger.info(fn -> "[#{__MODULE__}] Minted block with hash `#{final_block_hash}`, publishing..." end)
+
+        result = Daisy.Persistence.publish(Daisy.Persistence, final_block_hash)
+
+        # TODO: Add links in info
+        Logger.info(fn -> "[#{__MODULE__}] Published new block: #{inspect result}" end)
+      {:error, error} ->
+        Logger.error("[#{__MODULE__}] Error mining block: #{inspect error}")
+    end
+
+    # Queue up mining again
+    if interval, do: queue_mining(interval)
+
+    {:noreply, state}
+  end
+
+  # TODO: Track this ref so we can later stop mining
+  defp queue_mining(interval) do
+    Process.send_after(self(), {:mine_block, interval}, interval)
+  end
+
+  ## Client
+
+  @doc """
+  Forces publisher to publish a new block immediately.
+
+  TODO: This should reset the timer
+  """
+  @spec force_mine_block(identifier()) :: {:ok, Daisy.Block.block_hash} | {:error, any()}
+  def force_mine_block(server) do
+    GenServer.call(server, {:mine_block, nil}, @mine_timeout)
+  end
+
+end

--- a/lib/daisy/persistence.ex
+++ b/lib/daisy/persistence.ex
@@ -1,0 +1,75 @@
+defmodule Daisy.Persistence do
+  @moduledoc """
+  The persistence library is used to track blocks over time. This is kept
+  separate from `Daisy.Storage` because it is long-term mutable storage.
+  Additionally, the actions here are much (much) slower.
+
+  TODO: We should have the ability to store different objects at different
+        keys.
+  """
+  use GenServer
+
+  @type root_hash :: String.t
+  @type data_hash :: String.t
+
+  @timeout 60_000
+
+  def start_link(opts \\ []) do
+    host = Keyword.get(opts, :host, "localhost")
+    port = Keyword.get(opts, :port, "5001")
+    name = Keyword.get(opts, :name, nil)
+
+    gen_server_args = if name do
+      [name: name]
+    else
+      []
+    end
+
+    GenServer.start_link(__MODULE__, {host, port}, gen_server_args)
+  end
+
+  def init({host, port}) do
+    client = IPFS.Client.new(host, port)
+
+    {:ok, %{
+      client: client
+    }}
+  end
+
+  def handle_call({:publish, root_hash}, _from, %{client: client}=state) do
+    result = ipns_publish(client, root_hash)
+
+    {:reply, result, state}
+  end
+
+  def handle_call(:resolve, _from, %{client: client}=state) do
+    result = ipns_resolve(client)
+
+    {:reply, result, state}
+  end
+
+  @spec ipns_publish(IPFS.Client.t, root_hash) :: {:ok, String.t, String.t} | {:error, any()}
+  defp ipns_publish(client, root_hash) do
+    with {:ok, published} <- IPFS.Client.name_publish(client, root_hash) do
+      {:ok, published.name, published.value}
+    end
+  end
+
+  @spec ipns_resolve(IPFS.Client.t) :: {:ok, root_hash} | {:error, any()}
+  defp ipns_resolve(client) do
+    with {:ok, published} <- IPFS.Client.name_resolve(client) do
+      {:ok, published.value}
+    end
+  end
+
+  @spec publish(identifier(), root_hash) :: :ok | {:error, any()}
+  def publish(server, root_hash) do
+    GenServer.call(server, {:publish, root_hash}, @timeout)
+  end
+
+  @spec resolve(identifier()) :: {:ok, root_hash} | {:error, any()}
+  def resolve(server) do
+    GenServer.call(server, :resolve)
+  end
+
+end

--- a/lib/daisy/persistence.ex
+++ b/lib/daisy/persistence.ex
@@ -8,16 +8,20 @@ defmodule Daisy.Persistence do
         keys.
   """
   use GenServer
+  require Logger
 
   @type root_hash :: String.t
   @type data_hash :: String.t
+  @type key :: String.t
 
-  @timeout 60_000
+  @timeout 120_000
 
   def start_link(opts \\ []) do
     host = Keyword.get(opts, :host, "localhost")
     port = Keyword.get(opts, :port, "5001")
     name = Keyword.get(opts, :name, nil)
+    key_name = Keyword.get(opts, :key_name, nil)
+    key_id = Keyword.get(opts, :key_id, nil)
 
     gen_server_args = if name do
       [name: name]
@@ -25,51 +29,93 @@ defmodule Daisy.Persistence do
       []
     end
 
-    GenServer.start_link(__MODULE__, {host, port}, gen_server_args)
+    GenServer.start_link(__MODULE__, {key_name, key_id, host, port}, gen_server_args)
   end
 
-  def init({host, port}) do
+  def init({key_name, key_id, host, port}) do
     client = IPFS.Client.new(host, port)
 
+    {:ok, key} = get_key(client, key_name, key_id)
+
+    Logger.debug("[#{__MODULE__} Persistence using IPFS key `#{key.name}` (#{key.id})")
+
     {:ok, %{
-      client: client
+      client: client,
+      key: key.id
     }}
   end
 
-  def handle_call({:publish, root_hash}, _from, %{client: client}=state) do
-    result = ipns_publish(client, root_hash)
+  def handle_call({:publish, root_hash}, _from, %{client: client, key: key}=state) do
+    result = ipns_publish(client, root_hash, key)
 
     {:reply, result, state}
   end
 
-  def handle_call(:resolve, _from, %{client: client}=state) do
-    result = ipns_resolve(client)
+  def handle_cast({:publish, root_hash}, %{client: client, key: key}=state) do
+    {:ok, _name, _value} = ipns_publish(client, root_hash, key)
+
+    {:noreply, state}
+  end
+
+  def handle_call(:resolve, _from, %{client: client, key: key}=state) do
+    result = case ipns_resolve(client, key) do
+      {:ok, "/ipfs/" <> result} -> {:ok, result}
+      {:ok, invalid_result} -> {:error, "Invalid resolve result: `#{invalid_result}`"}
+      error={:error, %HTTPoison.Response{body: body}} ->
+        # Handle error case if not found specially
+        if String.contains?(body, "\"Code\":0") do
+          :not_found
+        else
+          error
+        end
+    end
 
     {:reply, result, state}
   end
 
-  @spec ipns_publish(IPFS.Client.t, root_hash) :: {:ok, String.t, String.t} | {:error, any()}
-  defp ipns_publish(client, root_hash) do
-    with {:ok, published} <- IPFS.Client.name_publish(client, root_hash) do
+  @spec ipns_publish(IPFS.Client.t, root_hash, key) :: {:ok, String.t, String.t} | {:error, any()}
+  defp ipns_publish(client, root_hash, key) do
+    with {:ok, published} <- IPFS.Client.name_publish(client, root_hash, key: key) do
       {:ok, published.name, published.value}
     end
   end
 
-  @spec ipns_resolve(IPFS.Client.t) :: {:ok, root_hash} | {:error, any()}
-  defp ipns_resolve(client) do
-    with {:ok, published} <- IPFS.Client.name_resolve(client) do
+  # TODO: Handle "not found" case
+  @spec ipns_resolve(IPFS.Client.t, key) :: {:ok, root_hash} | {:error, any()}
+  defp ipns_resolve(client, key) do
+    with {:ok, published} <- IPFS.Client.name_resolve(client, key, nocache: true) do
       {:ok, published.value}
     end
   end
+
+  @spec get_key(IPFS.Client.t, String.t | nil, String.t | nil) :: {:ok, IPFS.Client.Key.t} | {:error, any()}
+  defp get_key(client, nil, nil), do: IPFS.Client.key_gen(client, UUID.uuid4())
+  defp get_key(client, key_name, nil) do
+    {:ok, keys} = IPFS.Client.key_list(client)
+
+    key = Enum.find(keys, fn key -> key.name == key_name end)
+
+    if key do
+      {:ok, key}
+    else
+      {:error, "cannot find key #{key_name}"}
+    end
+  end
+  defp get_key(_client, key_name, key_id), do: {:ok, %IPFS.Client.Key{name: key_name || "", id: key_id}}
 
   @spec publish(identifier(), root_hash) :: :ok | {:error, any()}
   def publish(server, root_hash) do
     GenServer.call(server, {:publish, root_hash}, @timeout)
   end
 
-  @spec resolve(identifier()) :: {:ok, root_hash} | {:error, any()}
+  @spec publish_async(identifier(), root_hash) :: :ok | {:error, any()}
+  def publish_async(server, root_hash) do
+    GenServer.cast(server, {:publish, root_hash})
+  end
+
+  @spec resolve(identifier()) :: {:ok, root_hash} | :not_found | {:error, any()}
   def resolve(server) do
-    GenServer.call(server, :resolve)
+    GenServer.call(server, :resolve, @timeout)
   end
 
 end

--- a/lib/daisy/serializer/json_serializer.ex
+++ b/lib/daisy/serializer/json_serializer.ex
@@ -20,6 +20,7 @@ defmodule Daisy.Serializer.JSONSerializer do
   ```
 
   This serializer always encodes the final result as JSON.
+  TODO: Uhh, is this JSON anymore?
   """
   import Daisy.Encoder
 

--- a/lib/daisy/storage.ex
+++ b/lib/daisy/storage.ex
@@ -183,7 +183,7 @@ defmodule Daisy.Storage do
   @spec ipfs_put_all(IPFS.Client.t, root_hash, %{}) :: {:ok, binary()} | {:error, any()}
   def ipfs_put_all(client, root_hash, values) do
     Enum.reduce(values, {:ok, root_hash}, fn
-      {path, val}, {:ok, current_hash} when val == "" or val == %{} ->
+      {path, val}, {:ok, current_hash} when is_nil(val) or val == "" or val == %{} ->
         # Skip blank nodes / maps
         {:ok, current_hash}
       {path, data}, {:ok, current_hash} when is_binary(data) ->
@@ -264,6 +264,7 @@ defmodule Daisy.Storage do
 
   @spec ipfs_get(IPFS.Client.t, root_hash, String.t) :: {:ok, String.t} | :not_found | {:error, any()}
   defp ipfs_get(client, root_hash, path) do
+    IO.inspect(["Getting", client, root_hash, path])
     with {:ok, data_hash} <- ipfs_get_hash(client, root_hash, path) do
       with {:ok, data} <- ipfs_retrieve(client, data_hash) do
         {:ok, data}

--- a/mix.lock
+++ b/mix.lock
@@ -7,7 +7,7 @@
   "hackney": {:hex, :hackney, "1.11.0", "4951ee019df102492dabba66a09e305f61919a8a183a7860236c0fde586134b6", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.0.0", "1f02f827148d945d40b24f0b0a89afe40bfe037171a6cf70f2486976d86921cd", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
-  "ipfs_client": {:git, "https://github.com/hayesgm/elixir-ipfs-client.git", "7e19d735447d47bfd95aa9027171eb3ee95ea104", [branch: "hayesgm/add-potent-operations"]},
+  "ipfs_client": {:git, "https://github.com/hayesgm/elixir-ipfs-client.git", "fdd417dbef81cc684ba5027306ea742d830608e5", [branch: "hayesgm/add-potent-operations"]},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -7,7 +7,7 @@
   "hackney": {:hex, :hackney, "1.11.0", "4951ee019df102492dabba66a09e305f61919a8a183a7860236c0fde586134b6", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.0.0", "1f02f827148d945d40b24f0b0a89afe40bfe037171a6cf70f2486976d86921cd", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
-  "ipfs_client": {:git, "https://github.com/hayesgm/elixir-ipfs-client.git", "fdd417dbef81cc684ba5027306ea742d830608e5", [branch: "hayesgm/add-potent-operations"]},
+  "ipfs_client": {:git, "https://github.com/hayesgm/elixir-ipfs-client.git", "8d08da50a46260e1611ea8872d1b2a225efd5760", [branch: "hayesgm/add-potent-operations"]},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},

--- a/test/daisy/minter/minter_test.exs
+++ b/test/daisy/minter/minter_test.exs
@@ -75,7 +75,7 @@ defmodule Daisy.MinterTest do
       Minter.add_transaction(minter_pid, transaction)
       Minter.mine_block(minter_pid)
 
-      assert {:ok, 51} == Minter.read(minter_pid, "result", %{})
+      assert {:ok, 51} == Minter.read(minter_pid, "result", [])
     end
   end
 

--- a/test/daisy/persistence_test.exs
+++ b/test/daisy/persistence_test.exs
@@ -1,0 +1,31 @@
+defmodule Daisy.PersistenceTest do
+  use ExUnit.Case, async: true
+  doctest Daisy.Persistence
+
+  setup do
+    {:ok, storage_pid} = Daisy.Storage.start_link()
+    {:ok, persistence_pid} = Daisy.Persistence.start_link()
+
+    {:ok, %{
+      storage_pid: storage_pid,
+      persistence_pid: persistence_pid,
+    }}
+  end
+
+  describe "#publish/2" do
+    test "it should publish an object", %{storage_pid: storage_pid, persistence_pid: persistence_pid} do
+      {:ok, data_hash} = Daisy.Storage.save(storage_pid, "test")
+      ipfs_link = "/ipfs/#{data_hash}"
+      assert {:ok, _name, ^ipfs_link} = Daisy.Persistence.publish(persistence_pid, data_hash)
+    end
+  end
+
+  describe "#resolve/1" do
+    test "it should persist an object", %{storage_pid: storage_pid, persistence_pid: persistence_pid} do
+      {:ok, data_hash} = Daisy.Storage.save(storage_pid, "test")
+      Daisy.Persistence.persist(persistence_pid, data_hash)
+
+      assert {:ok, data_hash} == Daisy.Persistence.resolve(persistence_pid)
+    end
+  end
+end

--- a/test/daisy/persistence_test.exs
+++ b/test/daisy/persistence_test.exs
@@ -17,15 +17,20 @@ defmodule Daisy.PersistenceTest do
       {:ok, data_hash} = Daisy.Storage.save(storage_pid, "test")
       ipfs_link = "/ipfs/#{data_hash}"
       assert {:ok, _name, ^ipfs_link} = Daisy.Persistence.publish(persistence_pid, data_hash)
+
+      assert {:ok, data_hash} == Daisy.Persistence.resolve(persistence_pid)
     end
   end
 
   describe "#resolve/1" do
-    test "it should persist an object", %{storage_pid: storage_pid, persistence_pid: persistence_pid} do
-      {:ok, data_hash} = Daisy.Storage.save(storage_pid, "test")
-      Daisy.Persistence.persist(persistence_pid, data_hash)
+    test "it should persist an object (posted elsewhere)" do
+      {:ok, persistence_pid} = Daisy.Persistence.start_link(key_id: "QmdkpdEigZ677wg9ViUm8Vu2znroKSFC9Fu8ptaEqgX9Rz")
 
-      assert {:ok, data_hash} == Daisy.Persistence.resolve(persistence_pid)
+      assert {:ok, "QmVuetiw5MsWeKJKyKi9XE5UKTa47668ZV4MQVEJqe6pnL"} == Daisy.Persistence.resolve(persistence_pid)
+    end
+
+    test "it should handle not found", %{persistence_pid: persistence_pid} do
+      assert :not_found == Daisy.Persistence.resolve(persistence_pid)
     end
   end
 end


### PR DESCRIPTION
Currently, every time the protocol starts, it begins with a brand-new blockchain from scratch. We should instead opt to store the current block hash whenever we mine a new block and then push that blockhash to IPNS so that peers can also start from that blockhash. This patch begins to implement that strategy.