### PR TITLE
Begin to add Queued Transactions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,6 @@
 use Mix.Config
 
+config :daisy,
+  serializer: Daisy.Serializer.JSONSerializer
+
 import_config "#{Mix.env}.exs"

--- a/lib/daisy.ex
+++ b/lib/daisy.ex
@@ -6,5 +6,6 @@ defmodule Daisy do
   def get_runner(), do: Application.get_env(:daisy, :runner)
   def get_reader(), do: Application.get_env(:daisy, :reader)
   def get_ipfs_key(), do: Application.get_env(:daisy, :ipfs_key)
+  def get_serializer(), do: Application.get_env(:daisy, :serializer)
 
 end

--- a/lib/daisy/block.ex
+++ b/lib/daisy/block.ex
@@ -70,7 +70,7 @@ defmodule Daisy.Block do
       with {:ok, previous_block_number} <- block_number(parent_block_hash, storage_pid) do
         block_number = previous_block_number + 1
 
-        with {:ok, transaction_queue} <- Daisy.TransactionQueue.get_queue_for_block(storage_pid, parent_block_hash, block_number) do
+        with {:ok, transaction_queue} <- Daisy.TransactionQueue.get_queue_for_block(storage_pid, previous_block_final_storage, block_number) do
           {:ok, Daisy.Data.Block.new(
             block_number: block_number,
             parent_block_hash: parent_block_hash,

--- a/lib/daisy/examples/test.ex
+++ b/lib/daisy/examples/test.ex
@@ -23,8 +23,8 @@ defmodule Daisy.Examples.Test do
   defmodule Runner do
     @behaviour Daisy.Runner
 
-    @callback run_transaction(Daisy.Data.Invokation.t, identifier(), Daisy.Storage.root_hash, binary()) :: {:ok, Daisy.Runner.transaction_result} | {:error, any()}
-    def run_transaction(%Daisy.Data.Invokation{function: "test", args: [a_str, b_str]}, storage_pid, initial_storage, _owner) do
+    @callback run_transaction(Daisy.Data.Invokation.t, identifier(), Daisy.Storage.root_hash, integer(), binary()) :: {:ok, Daisy.Runner.transaction_result} | {:error, any()}
+    def run_transaction(%Daisy.Data.Invokation{function: "test", args: [a_str, b_str]}, storage_pid, initial_storage, _block_number, _owner) do
       # Store result
       a = String.to_integer(a_str)
       b = String.to_integer(b_str)

--- a/lib/daisy/minter/minter.ex
+++ b/lib/daisy/minter/minter.ex
@@ -36,9 +36,9 @@ defmodule Daisy.Minter do
 
             Daisy.Block.genesis_block(storage_pid)
           {:ok, block_hash} ->
-            Logger.debug("[#{__MODULE__}] Loading block #{block_hash}")
+            Logger.debug("[#{__MODULE__}] Creating new block from #{block_hash}")
 
-            Daisy.Block.load_block(storage_pid, block_hash)
+            Daisy.Block.new_block(block_hash, storage_pid, [])
           {:error, error} -> raise "[#{__MODULE__}] Error resolving block hash: #{inspect error}"
         end
       :genesis ->
@@ -99,7 +99,8 @@ defmodule Daisy.Minter do
   @spec server_mine_block(Daisy.Data.Block.t, identifier(), module()) :: {:ok, Daisy.Block.block_hash, Daisy.Data.Block.t} | {:error, any()}
   defp server_mine_block(block, storage_pid, runner) do
     # First, finalize the block
-    with {:ok, _finalized_block, final_block_hash} <- Daisy.Block.process_and_save_block(block, storage_pid, runner) do
+    with {:ok, finalized_block, final_block_hash} <- Daisy.Block.process_and_save_block(block, storage_pid, runner) do
+      Logger.debug("[#{__MODULE__}] Minted block #{inspect finalized_block}")
       # Finally, start a new block
       with {:ok, new_block} <- Daisy.Block.new_block(final_block_hash, storage_pid, []) do
         {:ok, final_block_hash, new_block}

--- a/lib/daisy/persistence.ex
+++ b/lib/daisy/persistence.ex
@@ -75,7 +75,7 @@ defmodule Daisy.Persistence do
 
   @spec ipns_publish(IPFS.Client.t, root_hash, key) :: {:ok, String.t, String.t} | {:error, any()}
   defp ipns_publish(client, root_hash, key) do
-    with {:ok, published} <- IPFS.Client.name_publish(client, root_hash, key: key) do
+    with {:ok, published} <- IPFS.Client.name_publish(client, root_hash, key: key, timeout: @timeout) do
       {:ok, published.name, published.value}
     end
   end

--- a/lib/daisy/proto/block.pb.ex
+++ b/lib/daisy/proto/block.pb.ex
@@ -2,17 +2,19 @@ defmodule Daisy.Data.Block do
   use Protobufex, syntax: :proto3
 
   @type t :: %__MODULE__{
-    previous_block_hash: String.t,
-    initial_storage:     String.t,
-    final_storage:       String.t,
-    transactions:        [Daisy.Data.Transaction.t],
-    receipts:            [Daisy.Data.Receipt.t]
+    block_number:      non_neg_integer,
+    parent_block_hash: String.t,
+    initial_storage:   String.t,
+    final_storage:     String.t,
+    transactions:      [Daisy.Data.Transaction.t],
+    receipts:          [Daisy.Data.Receipt.t]
   }
-  defstruct [:previous_block_hash, :initial_storage, :final_storage, :transactions, :receipts]
+  defstruct [:block_number, :parent_block_hash, :initial_storage, :final_storage, :transactions, :receipts]
 
-  field :previous_block_hash, 1, type: :string
-  field :initial_storage, 2, type: :string
-  field :final_storage, 3, type: :string
-  field :transactions, 4, repeated: true, type: Daisy.Data.Transaction
-  field :receipts, 5, repeated: true, type: Daisy.Data.Receipt
+  field :block_number, 1, type: :uint64
+  field :parent_block_hash, 2, type: :string
+  field :initial_storage, 3, type: :string
+  field :final_storage, 4, type: :string
+  field :transactions, 5, repeated: true, type: Daisy.Data.Transaction
+  field :receipts, 6, repeated: true, type: Daisy.Data.Receipt
 end

--- a/lib/daisy/proto/transaction.pb.ex
+++ b/lib/daisy/proto/transaction.pb.ex
@@ -16,10 +16,12 @@ defmodule Daisy.Data.Transaction do
 
   @type t :: %__MODULE__{
     invokation: Daisy.Data.Invokation.t,
-    signature:  Daisy.Data.Signature.t
+    signature:  Daisy.Data.Signature.t,
+    owner:      String.t
   }
-  defstruct [:invokation, :signature]
+  defstruct [:invokation, :signature, :owner]
 
   field :invokation, 1, type: Daisy.Data.Invokation
   field :signature, 2, type: Daisy.Data.Signature
+  field :owner, 3, type: :bytes
 end

--- a/lib/daisy/runner.ex
+++ b/lib/daisy/runner.ex
@@ -111,6 +111,8 @@ defmodule Daisy.Runner do
   Verifies an invokation is valid, returning, if valid, the public key
   of the signer.
 
+  TODO: Test queued owner transcations
+
   ## Examples
 
       iex> keypair = Daisy.RunnerTest.test_keypair()
@@ -124,6 +126,10 @@ defmodule Daisy.Runner do
       {:error, :invalid_signature}
   """
   @spec verify_invokation(Daisy.Data.Transaction.t) :: {:ok, binary()} | {:error, any()}
+  def verify_invokation(%Daisy.Data.Transaction{invokation: invokation, owner: owner}) when not is_nil(owner) and owner != <<>> do
+    {:ok, owner}
+  end
+
   def verify_invokation(%Daisy.Data.Transaction{invokation: invokation, signature: signature}) do
     invokation
     |> Daisy.Data.Invokation.encode()

--- a/lib/daisy/transaction_queue.ex
+++ b/lib/daisy/transaction_queue.ex
@@ -1,0 +1,51 @@
+defmodule Daisy.TransactionQueue do
+  @moduledoc """
+
+  TODO: We probably shouldn't actually encode/decode in this module
+  """
+
+  @storage_key "/transaction_queue"
+
+	@doc """
+  Queues an invokation to be run in a future block
+  """
+  @spec queue(identifier(), Daisy.Storage.root_hash, integer(), binary(), Daisy.Data.Invokation.t) :: {:ok, Daisy.Storage.root_hash} | {:error, any()}
+  def queue(storage_pid, storage, block_number, owner, invokation) do
+    with {:ok, transaction_queue_list} = Daisy.Storage.ls(storage_pid, storage, "#{@storage_key}/#{block_number}") do
+      transaction_queue_count = Enum.count(transaction_queue_list)
+
+      transaction = Daisy.Data.Transaction.new(
+        invokation: invokation,
+        owner: owner
+      )
+
+      Daisy.Storage.put(
+        storage_pid,
+        storage,
+        "#{@storage_key}/#{block_number}/#{transaction_queue_count + 1}",
+        Daisy.get_serializer().serialize_transaction(transaction) |> Poison.encode!
+      )
+    end
+  end
+
+  @doc """
+  Returns queue of all transactions for a given block number.
+  """
+  @spec get_queue_for_block(identifier(), Daisy.Storage.root_hash, integer()) :: {:ok, [Daisy.Data.Transaction.t]} | {:error, any()}
+  def get_queue_for_block(storage_pid, storage, block_number) do
+    serializer = Daisy.get_serializer()
+
+    case Daisy.Storage.get_all(storage_pid, storage, "#{@storage_key}/#{block_number}") do
+      {:ok, serialized_transaction_queue} ->
+        transaction_queue =
+          serialized_transaction_queue
+          |> Enum.map(fn {_k, v} -> v end)
+          |> Enum.map(&Poison.decode!/1)
+          |> Enum.map(&serializer.deserialize_transaction/1)
+
+        {:ok, transaction_queue}
+      :not_found -> {:ok, []}
+      els -> els
+    end
+  end
+end

--- a/priv/proto/block.proto
+++ b/priv/proto/block.proto
@@ -6,9 +6,10 @@ import "transaction.proto";
 package Daisy.Data;
 
 message Block {
-	string previous_block_hash = 1;
-	string initial_storage = 2;
-	string final_storage = 3;
-	repeated Transaction transactions = 4;
-	repeated Receipt receipts = 5;
+	uint64 block_number = 1;
+	string parent_block_hash = 2;
+	string initial_storage = 3;
+	string final_storage = 4;
+	repeated Transaction transactions = 5;
+	repeated Receipt receipts = 6;
 }

--- a/priv/proto/transaction.proto
+++ b/priv/proto/transaction.proto
@@ -11,5 +11,8 @@ message Invokation {
 
 message Transaction {
 	Invokation invokation = 1;
+
+	// This should be one-of?
 	Signature signature = 2;
+	bytes owner = 3;
 }

--- a/test/daisy/examples/kitten_test.exs
+++ b/test/daisy/examples/kitten_test.exs
@@ -28,7 +28,7 @@ defmodule Daisy.Examples.KittenTest do
       Daisy.Block.process_and_save_block(new_block, storage_pid, Kitten.Runner)
 
     assert processed_block == %Daisy.Data.Block{
-      previous_block_hash: "QmUatzSyhUCBeZvQEM8f56kSbrhEuguKESouHUoqsptz26",
+      parent_block_hash: "QmUatzSyhUCBeZvQEM8f56kSbrhEuguKESouHUoqsptz26",
       initial_storage: genesis_block.initial_storage,
       final_storage: genesis_block.initial_storage,
       transactions: [],

--- a/test/daisy/minter/minter_test.exs
+++ b/test/daisy/minter/minter_test.exs
@@ -19,9 +19,10 @@ defmodule Daisy.MinterTest do
   describe "#get_block/1" do
     test "it returns the current block", %{minter_pid: minter_pid} do
       assert %Daisy.Data.Block{
+        block_number: 0,
         final_storage: "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
         initial_storage: "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
-        previous_block_hash: "",
+        parent_block_hash: "",
         receipts: [],
         transactions: []
       } == Minter.get_block(minter_pid)
@@ -35,7 +36,7 @@ defmodule Daisy.MinterTest do
       assert %Daisy.Data.Block{
         final_storage: "",
         initial_storage: "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
-        previous_block_hash: "QmUatzSyhUCBeZvQEM8f56kSbrhEuguKESouHUoqsptz26",
+        parent_block_hash: "QmUatzSyhUCBeZvQEM8f56kSbrhEuguKESouHUoqsptz26",
         receipts: [],
         transactions: []
       } == Minter.get_block(minter_pid)
@@ -59,7 +60,7 @@ defmodule Daisy.MinterTest do
       block_hash = Minter.mine_block(minter_pid)
 
       assert %Daisy.Data.Block{
-        previous_block_hash: ^block_hash,
+        parent_block_hash: ^block_hash,
         receipts: [],
         transactions: []
       } = Minter.get_block(minter_pid)
@@ -89,14 +90,14 @@ defmodule Daisy.MinterTest do
 
       block_2 = Minter.get_block(minter_pid)
 
-      assert block_2.previous_block_hash != ""
+      assert block_2.parent_block_hash != ""
 
       :timer.sleep(600)
 
       block_3 = Minter.get_block(minter_pid)
 
-      assert block_3.previous_block_hash != ""
-      assert block_3.previous_block_hash != block_2.previous_block_hash
+      assert block_3.parent_block_hash != ""
+      assert block_3.parent_block_hash != block_2.parent_block_hash
     end
   end
 end

--- a/test/daisy/transaction_queue_test.exs
+++ b/test/daisy/transaction_queue_test.exs
@@ -1,0 +1,65 @@
+defmodule Daisy.TransactionQueueTest do
+  use ExUnit.Case, async: true
+  doctest Daisy.TransactionQueue
+  alias Daisy.TransactionQueue
+
+  setup_all do
+    {:ok, storage_pid} = Daisy.Storage.start_link()
+    {:ok, root_hash} = Daisy.Storage.new(storage_pid)
+
+    {:ok, %{
+      storage_pid: storage_pid,
+      root_hash: root_hash
+    }}
+  end
+
+  describe "#queue/5" do
+    test "it can enqueue and dequeue invokations", %{storage_pid: storage_pid, root_hash: root_hash} do
+      invokation = Daisy.Data.Invokation.new(
+        function: "abc",
+        args: ["1", "2", "3"]
+      )
+      {:ok, root_hash_1} = TransactionQueue.queue(storage_pid, root_hash, 5, <<1>>, invokation)
+
+      assert {:ok, []} == TransactionQueue.get_queue_for_block(storage_pid, root_hash, 5)
+      assert {:ok, [
+        %Daisy.Data.Transaction{
+          invokation: invokation,
+          owner: <<1>>,
+          signature: Daisy.Data.Signature.new()
+        }]
+      } == TransactionQueue.get_queue_for_block(storage_pid, root_hash_1, 5)
+
+      assert {:ok, []} == TransactionQueue.get_queue_for_block(storage_pid, root_hash_1, 6)
+    end
+  end
+
+  describe "#get_queue_for_block/3" do
+    test "it has correct transaction", %{storage_pid: storage_pid, root_hash: root_hash} do
+      invokation_1 = Daisy.Data.Invokation.new(
+        function: "abc",
+        args: ["1", "2", "3"]
+      )
+      invokation_2 = Daisy.Data.Invokation.new(
+        function: "def",
+        args: ["1"]
+      )
+      {:ok, root_hash_1} = TransactionQueue.queue(storage_pid, root_hash, 5, <<1>>, invokation_1)
+      {:ok, root_hash_2} = TransactionQueue.queue(storage_pid, root_hash_1, 5, <<2>>, invokation_2)
+
+      assert {:ok, [
+        %Daisy.Data.Transaction{
+          invokation: invokation_1,
+          owner: <<1>>,
+          signature: Daisy.Data.Signature.new()
+        },
+        %Daisy.Data.Transaction{
+          invokation: invokation_2,
+          owner: <<2>>,
+          signature: Daisy.Data.Signature.new()
+        }]
+      } == TransactionQueue.get_queue_for_block(storage_pid, root_hash_2, 5)
+    end
+  end
+
+end


### PR DESCRIPTION
This patch begins to add a concept of a Transaction Queue, where transactions can be queued to run at some point in the future (based on a block number). These are currently stored in "storage" with the rest of data, since it was the easiest place to put them (though we'll likely merge these concepts back into standard block storage). In either case, we store a list of transactions to run in the future and when that block is created, we put these transactions into the block automatically. We also (finally) attach a number to each block.