### PR TITLE
Start to add mix tasks to control running Daisy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ def deps do
 end
 ```
 
+## Starting Daisy
+
+To start Daisy in mining mode, run:
+
+```bash
+> mix daisy.miner
+```
+
 ## Design Mantras
 
 Daisy aims to be a side-chain. We have a few important design mantras to guide our process:
@@ -110,11 +118,11 @@ Daisy comes with a JSON-API to communicate with a node.
 
 ```bash
 # Read from current block
-curl http://localhost:2235/read/:my_func>/:my_arg_1/:my_arg_2/...
+curl http://localhost:2335/read/:my_func>/:my_arg_1/:my_arg_2/...
 {"result" => "good"}
 
 # Read from specified block
-curl http://localhost:2235/read/block/:block_hash/:my_func/:my_arg_1/:my_arg_2/...
+curl http://localhost:2335/read/block/:block_hash/:my_func/:my_arg_1/:my_arg_2/...
 {"result" => "good"}
 ```
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -3,4 +3,6 @@ use Mix.Config
 config :daisy,
   reader: Daisy.Examples.Kitten.Reader,
   runner: Daisy.Examples.Kitten.Runner,
-  ipfs_key: "miner"
+  ipfs_key: "miner",
+  run_miner: false,
+  run_api: false

--- a/lib/daisy.ex
+++ b/lib/daisy.ex
@@ -3,9 +3,4 @@ defmodule Daisy do
   Documentation for Daisy.
   """
 
-  def get_runner(), do: Application.get_env(:daisy, :runner)
-  def get_reader(), do: Application.get_env(:daisy, :reader)
-  def get_ipfs_key(), do: Application.get_env(:daisy, :ipfs_key)
-  def get_serializer(), do: Application.get_env(:daisy, :serializer)
-
 end

--- a/lib/daisy/application.ex
+++ b/lib/daisy/application.ex
@@ -2,25 +2,43 @@ defmodule Daisy.Application do
   use Application
 
   def start(_type, _args) do
-    runner = Daisy.get_runner()
-    reader = Daisy.get_reader()
-    ipfs_key = Daisy.get_ipfs_key()
+    runner = Daisy.Config.get_runner()
+    reader = Daisy.Config.get_reader()
+    ipfs_key = Daisy.Config.get_ipfs_key()
 
-    # Next, we'll stat persistence based on the key name in config
+    # TODO: Check that IPFS is up and available, when?
 
+    # Start Storage, Persistence and our Minter
     children = [
-      Plug.Adapters.Cowboy.child_spec(:http, Daisy.API.Router, [], [port: 2235]),
-      Supervisor.Spec.worker(Daisy.Storage, [[name: Daisy.Storage]])
-    ] ++ (if Mix.env == :test do
-      []
-    else
+      Supervisor.Spec.worker(Daisy.Storage, [[name: Daisy.Storage]]),
+      Supervisor.Spec.worker(Daisy.Persistence, [[key_name: ipfs_key, name: Daisy.Persistence]]),
+      Supervisor.Spec.worker(Daisy.Minter, [Daisy.Storage, :resolve, runner, reader, [name: Daisy.Minter]]),
+    ]
+
+    # If running API, start API server
+    children = if Daisy.Config.run_api?() do
+      port = Daisy.Config.get_port()
+      scheme = Daisy.Config.get_scheme()
+
       [
-        Supervisor.Spec.worker(Daisy.Persistence, [[key_name: ipfs_key, name: Daisy.Persistence]]),
-        Supervisor.Spec.worker(Daisy.Minter, [Daisy.Storage, :resolve, runner, reader, [name: Daisy.Minter]]),
-        Supervisor.Spec.worker(Daisy.Publisher, [Daisy.Minter, [name: Daisy.Publisher]]),
+        Plug.Adapters.Cowboy.child_spec(:http, Daisy.API.Router, [], [port: port])
+        | children
       ]
-    end)
+    else
+      children
+    end
+
+    # If running miner, start publisher
+    children = if Daisy.Config.run_miner?() do
+      [
+        Supervisor.Spec.worker(Daisy.Publisher, [Daisy.Minter, [name: Daisy.Publisher]])
+        | children
+      ]
+    else
+      children
+    end
 
     Supervisor.start_link(children, strategy: :one_for_one)
   end
+
 end

--- a/lib/daisy/block.ex
+++ b/lib/daisy/block.ex
@@ -181,7 +181,7 @@ defmodule Daisy.Block do
   @spec save_block(Daisy.Data.Block.t, identifier()) :: {:ok, block_hash} | {:error, any()}
   def save_block(block, storage_pid) do
     with {:ok, new_root_hash} <- Daisy.Storage.new(storage_pid) do
-      serialized_block = Daisy.get_serializer().serialize(block)
+      serialized_block = Daisy.Config.get_serializer().serialize(block)
 
       Daisy.Storage.put_all(
         storage_pid,
@@ -214,7 +214,7 @@ defmodule Daisy.Block do
   @spec load_block(identifier(), block_hash) :: {:ok, Daisy.Data.Block.t} | {:error, any()}
   def load_block(storage_pid, block_hash) do
     with {:ok, values} <- Daisy.Storage.get_all(storage_pid, block_hash) do
-      {:ok, Daisy.get_serializer().deserialize(values)}
+      {:ok, Daisy.Config.get_serializer().deserialize(values)}
     end
   end
 

--- a/lib/daisy/config.ex
+++ b/lib/daisy/config.ex
@@ -1,0 +1,46 @@
+defmodule Daisy.Config do
+  @default_port 2335
+  @default_scheme :http
+
+  @spec run_api? :: boolean()
+  def run_api? do
+    Application.get_env(:daisy, :run_api, false) |> IO.inspect
+  end
+
+  @spec run_miner? :: boolean()
+  def run_miner? do
+    Application.get_env(:daisy, :run_miner, false) |> IO.inspect
+  end
+
+  def get_runner(), do: Application.get_env(:daisy, :runner)
+  def get_reader(), do: Application.get_env(:daisy, :reader)
+  def get_ipfs_key(), do: Application.get_env(:daisy, :ipfs_key)
+  def get_serializer(), do: Application.get_env(:daisy, :serializer)
+
+  @spec get_port :: integer()
+  def get_port do
+    Application.get_env(:daisy, :api_port, @default_port)
+    |> maybe_system_var
+    |> as_integer
+  end
+
+  @spec get_scheme :: integer()
+  def get_scheme do
+    Application.get_env(:daisy, :api_scheme, @default_scheme)
+    |> maybe_system_var
+    |> as_scheme
+  end
+
+  @spec maybe_system_var({:system, String.t} | any()) :: String.t | any()
+  defp maybe_system_var({:system, var}), do: System.get_env(var)
+  defp maybe_system_var(els), do: els
+
+  defp as_integer(val) when is_integer(val), do: val
+  defp as_integer(val) when is_binary(val), do: String.to_integer(val)
+
+  defp as_scheme(val) when is_atom(val), do: val
+  defp as_scheme("http"), do: :http
+  defp as_scheme("https"), do: :https
+  defp as_scheme(els), do: raise "Invalid scheme, expected http or https, got `#{inspect els}`"
+
+end

--- a/lib/mix/tasks/daisy.ex
+++ b/lib/mix/tasks/daisy.ex
@@ -1,0 +1,28 @@
+defmodule Mix.Tasks.Daisy.Miner do
+  use Mix.Task
+
+  @shortdoc "Starts Daisy as a Miner"
+
+  @moduledoc """
+  Starts Daisy.
+
+  ## Command line options
+
+  The `--no-halt` flag is automatically added.
+  """
+
+  @doc false
+  def run(args) do
+    Application.put_env(:daisy, :run_api, true, persistent: true)
+    Application.put_env(:daisy, :run_miner, true, persistent: true)
+    Mix.Tasks.Run.run run_args() ++ args
+  end
+
+  defp run_args do
+    if iex_running?(), do: [], else: ["--no-halt"]
+  end
+
+  defp iex_running? do
+    Code.ensure_loaded?(IEx) and IEx.started?
+  end
+end


### PR DESCRIPTION
This patch adds the beginning of mix tasks to control running Daisy. This will make it possible for applications which include Daisy to run `mix daisy.miner` to start a mining node. Over time, we'll ramp up the available tasks, but we start with the most obvious for now.