### PR TITLE
[WIP] Add Signatures

### DIFF
--- a/lib/daisy/minter/publisher.ex
+++ b/lib/daisy/minter/publisher.ex
@@ -47,10 +47,14 @@ defmodule Daisy.Publisher do
       {:ok, final_block_hash} ->
         Logger.info(fn -> "[#{__MODULE__}] Minted block with hash `#{final_block_hash}`, publishing..." end)
 
-        result = Daisy.Persistence.publish(Daisy.Persistence, final_block_hash)
-
-        # TODO: Add links in info
-        Logger.info(fn -> "[#{__MODULE__}] Published new block: #{inspect result}" end)
+        case Daisy.Persistence.publish(Daisy.Persistence, final_block_hash) do
+          :ok ->
+            # TODO: Add links in info
+            Logger.info(fn -> "[#{__MODULE__}] Published new block." end)
+          {:error, error} ->
+            # TODO: Add links in info
+            Logger.error(fn -> "[#{__MODULE__}] Error pubishing new block: #{inspect error}" end)
+        end
       {:error, error} ->
         Logger.error("[#{__MODULE__}] Error mining block: #{inspect error}")
     end

--- a/lib/daisy/minter/publisher.ex
+++ b/lib/daisy/minter/publisher.ex
@@ -48,9 +48,9 @@ defmodule Daisy.Publisher do
         Logger.info(fn -> "[#{__MODULE__}] Minted block with hash `#{final_block_hash}`, publishing..." end)
 
         case Daisy.Persistence.publish(Daisy.Persistence, final_block_hash) do
-          :ok ->
+          {:ok, name, value} ->
             # TODO: Add links in info
-            Logger.info(fn -> "[#{__MODULE__}] Published new block." end)
+            Logger.info(fn -> "[#{__MODULE__}] Published new block. name=#{name}, value=#{value}" end)
           {:error, error} ->
             # TODO: Add links in info
             Logger.error(fn -> "[#{__MODULE__}] Error pubishing new block: #{inspect error}" end)

--- a/lib/daisy/persistence.ex
+++ b/lib/daisy/persistence.ex
@@ -103,7 +103,7 @@ defmodule Daisy.Persistence do
   end
   defp get_key(_client, key_name, key_id), do: {:ok, %IPFS.Client.Key{name: key_name || "", id: key_id}}
 
-  @spec publish(identifier(), root_hash) :: :ok | {:error, any()}
+  @spec publish(identifier(), root_hash) :: {:ok, String.t, String.t} | {:error, any()}
   def publish(server, root_hash) do
     GenServer.call(server, {:publish, root_hash}, @timeout)
   end

--- a/lib/daisy/signature.ex
+++ b/lib/daisy/signature.ex
@@ -69,4 +69,29 @@ defmodule Daisy.Signature do
     :crypto.generate_key(@key_type, @ec_curve)
   end
 
+  @doc """
+  Decodes a public key when given in ASN.1 DER form as a 'SubjectPublicKeyInfo'.
+  This is the form that is used when `-pubout -outform DER` is passed to
+  OpenSSL.
+
+  ## Examples
+
+      iex> "MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0NvcjVp5ZANisaXWjzKcnXMNVbwYU7Fa6ua0Nt+LNM7Lp8pOBy6kny6wvMvdwz4q0lQPn5y2VJlHCH7ILABOWQ=="
+      ...>   |> Base.decode64!
+      ...>   |> Daisy.Signature.decode_der_public_key()
+      {:ok,
+        <<4, 208, 219, 220, 141, 90, 121, 100, 3, 98, 177, 165, 214, 143,
+          50, 156, 157, 115, 13, 85, 188, 24, 83, 177, 90, 234, 230, 180,
+          54, 223, 139, 52, 206, 203, 167, 202, 78, 7, 46, 164, 159, 46,
+          176, 188, 203, 221, 195, 62, 42, 210, 84, 15, 159, 156, 182, 84,
+          153, 71, 8, 126, 200, 44, 0, 78, 89>>}
+  """
+  @spec decode_der_public_key(binary()) :: {:ok, public_key} | {:error, any()}
+  def decode_der_public_key(der_public_key) do
+    case :public_key.der_decode(:'SubjectPublicKeyInfo', der_public_key) do
+       {:'SubjectPublicKeyInfo', _, public_key} -> {:ok, public_key}
+       els -> {:error, "Invalid public key: #{inspect els}"}
+    end
+  end
+
 end

--- a/lib/daisy/transaction_queue.ex
+++ b/lib/daisy/transaction_queue.ex
@@ -23,7 +23,7 @@ defmodule Daisy.TransactionQueue do
         storage_pid,
         storage,
         "#{@storage_key}/#{block_number}/#{transaction_queue_count + 1}",
-        Daisy.get_serializer().serialize_transaction(transaction) |> Poison.encode!
+        Daisy.Config.get_serializer().serialize_transaction(transaction) |> Poison.encode!
       )
     end
   end
@@ -33,7 +33,7 @@ defmodule Daisy.TransactionQueue do
   """
   @spec get_queue_for_block(identifier(), Daisy.Storage.root_hash, integer()) :: {:ok, [Daisy.Data.Transaction.t]} | {:error, any()}
   def get_queue_for_block(storage_pid, storage, block_number) do
-    serializer = Daisy.get_serializer()
+    serializer = Daisy.Config.get_serializer()
 
     case Daisy.Storage.get_all(storage_pid, storage, "#{@storage_key}/#{block_number}") do
       {:ok, serialized_transaction_queue} ->

--- a/script/ipfs/key_gen
+++ b/script/ipfs/key_gen
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "$#" -lt 1 ]; then
+	printf "generates a new ipfs key\n\nusage:\n\tscript/ipfs/new_key <key_name>\n\n"
+	exit 1
+fi
+
+ipfs key gen -t rsa -s 3072 "$1"


### PR DESCRIPTION
This patch begins to add signatures to Daisy. This means that an account can prepare and then sign a transaction before submitting it to the blockchain. The hope, in the beginning, is that a user can do this through openssl directly. Here is an example:

(Note: the version of openssl that ships with macOS is about 6 years old, so we use a different version installed by homebrew but that is unlinked)

```bash
/usr/local/opt/openssl/bin/openssl ecparam -genkey -name secp256k1 -noout -out ./private_key.pem

/usr/local/opt/openssl/bin/openssl ec -in ./private_key.pem -pubout -outform DER -out ./public_key.der

public_key=$(cat ./public_key.der | base64)

signature=$(curl localhost:2335/prepare/spawn/15 -s | base64 -D | /usr/local/opt/openssl/bin/openssl dgst -sha256 -sign ./private_key.pem | base64)

curl -X POST http://localhost:2335/run/spawn/15 --data-urlencode "signature=$signature" --data-urlencode "public_key=$public_key"
```