### PR TITLE
Add a Link System

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :daisy,
-  serializer: Daisy.Serializer.JSONSerializer,
+  serializer: Daisy.Serializer,
   run_leader: false,
   run_follower: false,
   run_api: false,

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,6 +4,7 @@ config :daisy,
   serializer: Daisy.Serializer.JSONSerializer,
   run_leader: false,
   run_follower: false,
-  run_api: false
+  run_api: false,
+  initial_block_reference: :genesis
 
 import_config "#{Mix.env}.exs"

--- a/lib/daisy/application.ex
+++ b/lib/daisy/application.ex
@@ -35,12 +35,12 @@ defmodule Daisy.Application do
     children = children ++ cond do
       Daisy.Config.run_leader?() ->
         [
-          Supervisor.Spec.worker(Daisy.Tracker, [Daisy.Storage, initial_block_reference, runner, reader, [name: Daisy.Tracker]]),
+          Supervisor.Spec.worker(Daisy.Tracker, [Daisy.Storage, initial_block_reference, :leader, runner, reader, [name: Daisy.Tracker]]),
           Supervisor.Spec.worker(Daisy.Tracker.Leader, [Daisy.Tracker, [name: Daisy.Tracker.Leader]])
         ]
       Daisy.Config.run_follower?() ->
         [
-          Supervisor.Spec.worker(Daisy.Tracker, [Daisy.Storage, initial_block_reference, nil, reader, [name: Daisy.Tracker]]),
+          Supervisor.Spec.worker(Daisy.Tracker, [Daisy.Storage, initial_block_reference, :follower, runner, reader, [name: Daisy.Tracker]]),
           Supervisor.Spec.worker(Daisy.Tracker.Follower, [Daisy.Tracker, Daisy.Storage, [name: Daisy.Tracker.Follower]])
         ]
       true ->

--- a/lib/daisy/application.ex
+++ b/lib/daisy/application.ex
@@ -6,6 +6,7 @@ defmodule Daisy.Application do
     runner = Daisy.Config.get_runner()
     reader = Daisy.Config.get_reader()
     ipfs_key = Daisy.Config.get_ipfs_key()
+    initial_block_reference = Daisy.Config.initial_block_reference()
 
     # TODO: Check that IPFS is up and available, when?
 
@@ -34,12 +35,12 @@ defmodule Daisy.Application do
     children = children ++ cond do
       Daisy.Config.run_leader?() ->
         [
-          Supervisor.Spec.worker(Daisy.Tracker, [Daisy.Storage, :resolve, runner, reader, [name: Daisy.Tracker]]),
+          Supervisor.Spec.worker(Daisy.Tracker, [Daisy.Storage, initial_block_reference, runner, reader, [name: Daisy.Tracker]]),
           Supervisor.Spec.worker(Daisy.Tracker.Leader, [Daisy.Tracker, [name: Daisy.Tracker.Leader]])
         ]
       Daisy.Config.run_follower?() ->
         [
-          Supervisor.Spec.worker(Daisy.Tracker, [Daisy.Storage, :resolve, nil, reader, [name: Daisy.Tracker]]),
+          Supervisor.Spec.worker(Daisy.Tracker, [Daisy.Storage, initial_block_reference, nil, reader, [name: Daisy.Tracker]]),
           Supervisor.Spec.worker(Daisy.Tracker.Follower, [Daisy.Tracker, Daisy.Storage, [name: Daisy.Tracker.Follower]])
         ]
       true ->

--- a/lib/daisy/block.ex
+++ b/lib/daisy/block.ex
@@ -27,7 +27,7 @@ defmodule Daisy.Block do
   """
   @spec final_storage(block_hash, identifier()) :: {:ok, Daisy.Storage.root_hash} | {:error, any()}
   def final_storage(block_hash, storage_pid) do
-    case read_data_from_block_hash(block_hash, storage_pid, "block/final_storage") do
+    case read_link_from_block_hash(block_hash, storage_pid, "final_storage_link") do
       {:ok, final_storage} -> {:ok, final_storage}
       :not_found -> Daisy.Storage.new(storage_pid)
       els -> els
@@ -48,7 +48,7 @@ defmodule Daisy.Block do
   """
   @spec block_number(block_hash, identifier()) :: {:ok, Daisy.Storage.root_hash} | {:error, any()}
   def block_number(block_hash, storage_pid) do
-    with {:ok, block_number} <- read_data_from_block_hash(block_hash, storage_pid, "block/number") do
+    with {:ok, block_number} <- read_data_from_block_hash(block_hash, storage_pid, "block_number") do
       {:ok, block_number |> String.to_integer}
     end
   end
@@ -56,6 +56,14 @@ defmodule Daisy.Block do
   # TODO: Make a public function?
   defp read_data_from_block_hash(block_hash, storage_pid, path) do
     case Daisy.Storage.get(storage_pid, block_hash, path) do
+      {:ok, value} -> {:ok, value}
+      :not_found -> {:error, "cannot find #{path} in stored block `#{block_hash}`"}
+      els -> els
+    end
+  end
+
+  defp read_link_from_block_hash(block_hash, storage_pid, path) do
+    case Daisy.Storage.get_hash(storage_pid, block_hash, path) do
       {:ok, value} -> {:ok, value}
       :not_found -> {:error, "cannot find #{path} in stored block `#{block_hash}`"}
       els -> els

--- a/lib/daisy/block/builder.ex
+++ b/lib/daisy/block/builder.ex
@@ -13,8 +13,8 @@ defmodule Daisy.Block.Builder do
       iex> {:ok, storage_pid} = Daisy.Storage.start_link()
       iex> Daisy.Block.Builder.genesis_block(storage_pid)
       {:ok, %Daisy.Data.Block{
-        block_number: 0,
-        parent_block_hash: "",
+        block_number: 1,
+        parent_block_hash: "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
         initial_storage: "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
         final_storage: "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
         transactions: [],
@@ -25,7 +25,8 @@ defmodule Daisy.Block.Builder do
   def genesis_block(storage_pid) do
     with {:ok, initial_storage} <- Daisy.Storage.new(storage_pid) do
       {:ok, Daisy.Data.Block.new(
-        block_number: 0,
+        block_number: 1,
+        parent_block_hash: initial_storage,
         initial_storage: initial_storage,
         final_storage: initial_storage,
         transactions: []

--- a/lib/daisy/block/chain.ex
+++ b/lib/daisy/block/chain.ex
@@ -73,6 +73,8 @@ defmodule Daisy.Block.Chain do
   """
   @spec compare_blocks(Daisy.Data.Block.t, Daisy.Data.Block.t) :: :match | {:mismatch, [{atom(), any(), any()}]}
   def compare_blocks(block_a, block_b) do
+    IO.inspect(["Comparing", block_a, block_b])
+
     mismatches = Enum.reduce(Map.from_struct(block_a), [], fn {k, v1}, mismatches ->
       if (v2 = Map.get(block_b, k)) == v1 do
         mismatches

--- a/lib/daisy/config.ex
+++ b/lib/daisy/config.ex
@@ -2,6 +2,11 @@ defmodule Daisy.Config do
   @default_port 2335
   @default_scheme :http
 
+  @spec initial_block_reference :: any()
+  def initial_block_reference do
+    Application.get_env(:daisy, :initial_block_reference, :resolve)
+  end
+
   @spec run_api? :: boolean()
   def run_api? do
     Application.get_env(:daisy, :run_api, false)

--- a/lib/daisy/examples/kitten.ex
+++ b/lib/daisy/examples/kitten.ex
@@ -3,13 +3,14 @@ defmodule Daisy.Examples.Kitten do
   Kitten is an example Daisy library. This emulates a simple crypto-kitty
   like world.
   """
+  alias Daisy.Random
 
   defmodule Data do
     defmodule Kitten do
-      defstruct [:uuid, :name, :owner]
+      defstruct [:id, :name, :owner]
 
       @type t :: %__MODULE__{
-        uuid: String.t,
+        id: String.t,
         name: String.t,
         owner: String.t | nil
       }
@@ -19,7 +20,7 @@ defmodule Daisy.Examples.Kitten do
         kitten_data = Poison.decode!(kitten_json)
 
         %__MODULE__{
-          uuid: kitten_data["uuid"],
+          id: kitten_data["id"],
           name: kitten_data["name"],
           owner: kitten_data["owner"] |> Daisy.Encoder.maybe_decode_58!,
         }
@@ -28,7 +29,7 @@ defmodule Daisy.Examples.Kitten do
       @spec serialize(t) :: String.t
       def serialize(kitten) do
         %{
-          "uuid" => kitten.uuid,
+          "id" => kitten.id,
           "name" => kitten.name,
           "owner" => kitten.owner |> Daisy.Encoder.maybe_encode_58,
         } |> Poison.encode!
@@ -54,15 +55,15 @@ defmodule Daisy.Examples.Kitten do
       end
 
       @spec add_new(t, String.t) :: t
-      def add_new(orphan, uuid) do
+      def add_new(orphan, id) do
         orphan
-        |> Kernel.++([uuid])
+        |> Kernel.++([id])
       end
 
       @spec remove(t, String.t) :: t
-      def remove(orphan, uuid) do
+      def remove(orphan, id) do
         orphan
-        |> Enum.reject(&(&1 == uuid))
+        |> Enum.reject(&(&1 == id))
       end
     end
   end
@@ -79,14 +80,14 @@ defmodule Daisy.Examples.Kitten do
       end
     end
 
-    def read("is_orphan?", [kitten_uuid], storage_pid, storage) do
+    def read("is_orphan?", [kitten_id], storage_pid, storage) do
       with {:ok, orphans} <- read("orphans", [], storage_pid, storage) do
-        {:ok, Enum.member?(orphans, kitten_uuid)}
+        {:ok, Enum.member?(orphans, kitten_id)}
       end
     end
 
-    def read("kitten", [kitten_uuid], storage_pid, storage) do
-      with {:ok, kitten_json} <- Daisy.Storage.get(storage_pid, storage, "/kittens/#{kitten_uuid}") do
+    def read("kitten", [kitten_id], storage_pid, storage) do
+      with {:ok, kitten_json} <- Daisy.Storage.get(storage_pid, storage, "/kittens/#{kitten_id}") do
         {:ok, Data.Kitten.deserialize(kitten_json)}
       end
     end
@@ -100,12 +101,14 @@ defmodule Daisy.Examples.Kitten do
 
     @callback run_transaction(Daisy.Data.Invokation.t, identifier(), Daisy.Storage.root_hash, integer(), binary()) :: {:ok, Daisy.Runner.transaction_result} | {:error, any()}
     def run_transaction(%Daisy.Data.Invokation{function: "spawn", args: [cooldown]}, storage_pid, initial_storage, block_number, owner) do
-      # Generate a new random identifier and name
-      first_name = @first_names |> Enum.random
-      title = @titles |> Enum.random
+      # Generate a new pseudo-random identifier and name
+      rand = Random.init(block_number)
+      {rand, first_name} = Random.random_el(rand, @first_names)
+      {rand, title} = Random.random_el(rand, @titles)
+      {_rand, kitten_id} = Random.unique_id(rand)
 
       kitten = %Data.Kitten{
-        uuid: UUID.uuid4(),
+        id: kitten_id,
         name: "#{first_name} #{title}"
       }
 
@@ -113,7 +116,7 @@ defmodule Daisy.Examples.Kitten do
       {:ok, storage_with_kitten} = Daisy.Storage.put_new(
         storage_pid,
         initial_storage,
-        "/kittens/#{kitten.uuid}",
+        "/kittens/#{kitten.id}",
         kitten |> Data.Kitten.serialize)
 
       # Add new kitten to list of orphans
@@ -121,7 +124,7 @@ defmodule Daisy.Examples.Kitten do
       {:ok, storage_with_kitten_as_orphan} = Daisy.Storage.update(storage_pid, storage_with_kitten, "/orphans", fn orphan_json ->
         orphan_json
         |> Data.Orphan.deserialize
-        |> Data.Orphan.add_new(kitten.uuid)
+        |> Data.Orphan.add_new(kitten.id)
         |> Data.Orphan.serialize
       end, default: "", run_update_fn_on_default: true)
 
@@ -140,19 +143,19 @@ defmodule Daisy.Examples.Kitten do
       {:ok, %{
         final_storage: storage_with_queued_transaction,
         logs: [
-          "Added new kitten #{kitten.uuid} from owner #{inspect owner}"
+          "Added new kitten #{kitten.id} from owner #{inspect owner}"
         ],
         debug: inspect kitten
       }}
     end
 
-    def run_transaction(%Daisy.Data.Invokation{function: "adopt", args: [kitten_uuid]}, storage_pid, storage_1, _block_number, owner) do
+    def run_transaction(%Daisy.Data.Invokation{function: "adopt", args: [kitten_id]}, storage_pid, storage_1, _block_number, owner) do
       # First, check to see that the kitten is up for adoption
-      case Reader.read("is_orphan?", [kitten_uuid], storage_pid, storage_1) do
+      case Reader.read("is_orphan?", [kitten_id], storage_pid, storage_1) do
         {:ok, false} ->
           {:ok, %{
             status: :failure,
-            logs: ["Kitten #{kitten_uuid} not up for adoption"]
+            logs: ["Kitten #{kitten_id} not up for adoption"]
           }}
         {:error, error} -> {:error, error}
         {:ok, true} ->
@@ -160,12 +163,12 @@ defmodule Daisy.Examples.Kitten do
           {:ok, storage_2} = Daisy.Storage.update(storage_pid, storage_1, "/orphans", fn orphan_json ->
             orphan_json
             |> Data.Orphan.deserialize
-            |> Data.Orphan.remove(kitten_uuid)
+            |> Data.Orphan.remove(kitten_id)
             |> Data.Orphan.serialize
           end)
 
           # Add kitten as adopted
-          {:ok, storage_3} = Daisy.Storage.update(storage_pid, storage_2, "/kittens/#{kitten_uuid}", fn kitten_json ->
+          {:ok, storage_3} = Daisy.Storage.update(storage_pid, storage_2, "/kittens/#{kitten_id}", fn kitten_json ->
             kitten_json
             |> Data.Kitten.deserialize
             |> Map.put(:owner, owner)
@@ -175,7 +178,7 @@ defmodule Daisy.Examples.Kitten do
           {:ok, %{
             final_storage: storage_3,
             logs: [
-              "Owner #{inspect owner} adopted kitten #{kitten_uuid}"
+              "Owner #{inspect owner} adopted kitten #{kitten_id}"
             ]
           }}
       end

--- a/lib/daisy/ipfs.ex
+++ b/lib/daisy/ipfs.ex
@@ -1,0 +1,196 @@
+defmodule Daisy.IPFS do
+  @moduledoc """
+  Functions for interacting with IPFS. These are primarily used by
+  `Daisy.Storage`.
+  """
+
+  @type root_hash :: String.t
+  @type data_hash :: String.t
+
+  @empty_data_proto <<8, 1>>
+
+  @spec ipfs_new(IPFS.Client.t) :: {:ok, root_hash} | {:error, any()}
+  def ipfs_new(client) do
+    with {:ok, %IPFS.Client.PatchObject{hash: root_hash}} <- IPFS.Client.object_put(client, @empty_data_proto, true) do
+      {:ok, root_hash}
+    end
+  end
+
+  @spec ipfs_put(IPFS.Client.t, root_hash, String.t, String.t) :: {:ok, root_hash} | {:error, any()}
+  def ipfs_put(client, root_hash, path, data) do
+    # First, add the object
+    with {:ok, data_hash} <- ipfs_save(client, data) do
+      # Then, add to hash
+      ipfs_add_link(client, root_hash, path, data_hash)
+    end
+  end
+
+  @spec ipfs_add_link(IPFS.Client.t, root_hash, String.t, String.t) :: {:ok, root_hash} | {:error, any()}
+  def ipfs_add_link(client, root_hash, path, data_hash) do
+    with {:ok, %IPFS.Client.PatchObject{hash: new_root_hash}} <- IPFS.Client.object_patch_add_link(client, root_hash, path, data_hash, true) do
+      {:ok, new_root_hash}
+    end
+  end
+
+  @spec ipfs_save(IPFS.Client.t, String.t) :: {:ok, root_hash} | {:error, any()}
+  def ipfs_save(client, data) do
+    with {:ok, %IPFS.Client.PatchObject{hash: data_hash}} <- IPFS.Client.object_put(client, data, false) do
+      {:ok, data_hash}
+    end
+  end
+
+  @spec ipfs_put_all(IPFS.Client.t, root_hash, %{}) :: {:ok, binary()} | {:error, any()}
+  def ipfs_put_all(client, root_hash, values) do
+    Enum.reduce(values, {:ok, root_hash}, fn
+      {path, val}, {:ok, current_hash} when is_nil(val) or val == "" or val == %{} or val == {:link, ""} ->
+        # Skip blank nodes / maps
+        {:ok, current_hash}
+      {path, {:link, link}}, {:ok, current_hash} ->
+        # Directly put a link postfixed with _link
+        # TODO: Test
+        ipfs_add_link(client, current_hash, path <> "_link", link)
+      {path, data}, {:ok, current_hash} when is_binary(data) ->
+        # Put a simple value
+        ipfs_put(client, current_hash, path, data)
+      {path, values}, {:ok, current_hash} when is_map(values) ->
+        # Put a block of values
+        hash_result = case ipfs_get_hash(client, current_hash, path) do
+          {:ok, existing_root_hash} -> {:ok, existing_root_hash}
+          :not_found -> ipfs_new(client)
+          {:error, error} -> {:error, error}
+        end
+
+        with {:ok, hash_result_hash} <- hash_result do
+          with {:ok, values_root_hash} <- ipfs_put_all(client, hash_result_hash, values) do
+            # Link the new block to the current hash
+            ipfs_add_link(client, current_hash, path, values_root_hash)
+          end
+        end
+      _, {:error, error} -> {:error, error}
+    end)
+  end
+
+  @spec ipfs_get_all(IPFS.Client.t, root_hash) :: {:ok, %{}} | :not_found | {:error, any()}
+  def ipfs_get_all(client, root_hash) do
+    case do_ipfs_get_all(client, root_hash) do
+      {:ok, map} when is_map(map) ->
+        {:ok, map}
+      {:ok, data} when is_binary(data) ->
+        {:error, "expected root, got data: #{inspect data}"}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  @spec do_ipfs_get_all(IPFS.Client.t, root_hash) :: {:ok, %{} | String.t} | {:error, any()}
+  defp do_ipfs_get_all(client, root_hash) do
+    case ipfs_retrieve_all(client, root_hash) do
+      {:ok, data, links} when data == <<>> or data == @empty_data_proto ->
+        # This can probably be parallelized
+        Enum.reduce(links, {:ok, %{}}, fn
+          {name, hash}, {:ok, map} ->
+            # TODO: Maybe come up with a smarter system
+            if String.ends_with?(name, "_link") do
+              # This just stips the `_link` suffix and does not recurse
+              {:ok, Map.put(map, String.replace_suffix(name, "_link", ""), {:link, hash})}
+            else
+              with {:ok, result} = do_ipfs_get_all(client, hash) do
+                {:ok, Map.put(map, name, result)}
+              end
+            end
+          _, {:error, error} -> {:error, error}
+        end)
+      {:ok, data, []} ->
+        {:ok, data}
+      {:ok, data, links} -> {:error, "got both data and links, data=#{inspect data}, links=#{inspect links}"}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  @spec ipfs_retrieve(IPFS.Client.t, data_hash) :: {:ok, binary()} | {:error, any()}
+  def ipfs_retrieve(client, data_hash) do
+    with {:ok, %IPFS.Client.Object{data: data}} <- IPFS.Client.object_get(client, data_hash) do
+      {:ok, data}
+    end
+  end
+
+  @spec ipfs_retrieve_all(IPFS.Client.t, data_hash) :: {:ok, String.t, [{String.t, data_hash}]} | {:error, any()}
+  def ipfs_retrieve_all(client, data_hash) do
+    with {:ok, %IPFS.Client.Object{data: data, links: links}} <- IPFS.Client.object_get(client, data_hash) do
+      simple_links = for link <- links do
+        {link.name, link.hash}
+      end
+
+      {:ok, data, simple_links}
+    end
+  end
+
+  @spec ipfs_retrieve_proto(IPFS.Client.t, root_hash) :: {:ok, binary()} | {:error, any()}
+  def ipfs_retrieve_proto(client, hash) do
+    with {:ok, proto} <- IPFS.Client.object_get_protobuf(client, hash) do
+      {:ok, proto}
+    end
+  end
+
+  @spec ipfs_get(IPFS.Client.t, root_hash, String.t) :: {:ok, String.t} | :not_found | {:error, any()}
+  def ipfs_get(client, root_hash, path) do
+    with {:ok, data_hash} <- ipfs_get_hash(client, root_hash, path) do
+      with {:ok, data} <- ipfs_retrieve(client, data_hash) do
+        {:ok, data}
+      end
+    end
+  end
+
+  @spec ipfs_get_hash(IPFS.Client.t, root_hash, String.t) :: {:ok, String.t} | :not_found | {:error, any()}
+  def ipfs_get_hash(client, root_hash, path) do
+    # Note: This might be slow since we need to walk entire path to find file
+    case walk_path(client, path, root_hash) do
+      {:ok, [], _found_path, _found_objects, _found_links, data_hash} ->
+        {:ok, data_hash}
+      {:ok, _looking_path, _found_path, _found_objects, _found_links, _data_hash} -> :not_found
+      els -> els
+    end
+  end
+
+  @spec ipfs_get_links(IPFS.Client.t, root_hash, String.t) :: {:ok, [{String.t, data_hash}]} | :not_found | {:error, any()}
+  def ipfs_get_links(client, root_hash, path) do
+    # Note: This might be slow since we need to walk entire path to find file
+    case walk_path(client, path, root_hash) do
+      {:ok, [], _found_path, _found_objects, _found_links, data_hash} ->
+        with {:ok, _data, links} <- ipfs_retrieve_all(client, data_hash) do
+          {:ok, links}
+        end
+      {:ok, _looking_path, _found_path, _found_objects, _found_links, _data_hash} -> :not_found
+      els -> els
+    end
+  end
+
+  # Walks down a path as far as possible until it reaches the final path
+  # node or, if it fails, returns the last node on that path.
+  @spec walk_path(IPFS.Client.t, String.t, root_hash) :: {:ok, [String.t], [String.t], [IPFS.Client.Object.t], root_hash} | {:error, any()}
+  def walk_path(client, path, root_hash) do
+    result = do_walk_path(client, Path.split(path), [], [], [], root_hash)
+
+    with {:ok, looking_path, found_path_reverse, found_objects, found_links, root_hash} <- result do
+      {:ok, looking_path, found_path_reverse |> Enum.reverse, found_objects, found_links, root_hash}
+    end
+  end
+
+  @spec do_walk_path(IPFS.Client.t, [String.t], [String.t], [IPFS.Client.Object.t], [String.t], root_hash) :: {:ok, [String.t], [String.t], [IPFS.Client.Object.t], root_hash} | {:error, any()}
+  defp do_walk_path(_client, [], found_path, found_objects, found_links, root_hash), do: {:ok, [], found_path, found_objects, found_links, root_hash}
+  defp do_walk_path(client, [sub_path|path]=looking_path, found_path, found_objects, found_links, root_hash) do
+    ipfs_result = IPFS.Client.object_get(client, root_hash)
+
+    with {:ok, %IPFS.Client.Object{links: links}=object} <- ipfs_result do
+      # Look for a link matching sub_path
+      link = Enum.find(links, fn link -> link.name == sub_path end)
+
+      # If we find it, recurse, otherwise, we're done
+      if link do
+        do_walk_path(client, path, [sub_path|found_path], [object|found_objects], [root_hash|found_links], link.hash)
+      else
+        {:ok, looking_path, found_path, found_objects, found_links, root_hash}
+      end
+    end
+  end
+
+end

--- a/lib/daisy/random.ex
+++ b/lib/daisy/random.ex
@@ -1,0 +1,57 @@
+defmodule Daisy.Random do
+  @moduledoc """
+  Simple module to keep our randoms looking random, but in truth, fully
+  deterministic.
+  """
+
+  def init(seed) do
+    {0, seed}
+  end
+
+  def random_el(rand, list) do
+    list_length = list |> Enum.count
+
+    el =
+      rand
+      |> generate()
+      |> sha256_int
+      |> rem(list_length)
+
+    {next(rand), Enum.at(list, el)}
+  end
+
+  def unique_id(rand) do
+    <<bytes::binary-size(20), _rest::binary>> =
+      rand
+      |> generate()
+      |> sha256
+
+    {next(rand), bytes |> Base.encode16(case: :lower)}
+  end
+
+  defp sha256(int) do
+    int
+    |> :binary.encode_unsigned()
+    |> do_sha256
+  end
+
+  defp sha256_int(int) do
+    int
+    |> :binary.encode_unsigned()
+    |> do_sha256
+    |> :binary.decode_unsigned()
+  end
+
+  defp do_sha256(bin) do
+    :crypto.hash(:sha256, bin)
+  end
+
+  defp generate({acc, seed}) do
+    acc * 1_000_000_000_000_000_000 + seed
+  end
+
+  defp next({acc, seed}) do
+    {acc + 1, seed}
+  end
+
+end

--- a/lib/daisy/serializer.ex
+++ b/lib/daisy/serializer.ex
@@ -252,7 +252,8 @@ defmodule Daisy.Serializer do
       ...>   invokation: %Daisy.Data.Invokation{
       ...>     function: "func",
       ...>     args: ["red", "tree"]
-      ...>   }
+      ...>   },
+      ...>   owner: <<>>
       ...> }
       ...> |> Daisy.Serializer.serialize_transaction()
       %{
@@ -263,6 +264,10 @@ defmodule Daisy.Serializer do
       }
 
       iex> %Daisy.Data.Transaction{
+      ...>   signature: %Daisy.Data.Signature{
+      ...>     signature: <<>>,
+      ...>     public_key: <<>>
+      ...>   },
       ...>   invokation: %Daisy.Data.Invokation{
       ...>     function: "func",
       ...>     args: ["red", "tree"]
@@ -284,13 +289,13 @@ defmodule Daisy.Serializer do
     }
 
     cond do
-      transaction.signature ->
+      transaction.owner && transaction.owner != <<>> ->
+        base
+          |> Map.put("owner", encode_58(transaction.owner))
+      transaction.signature.signature && transaction.signature.signature != <<>> ->
         base
           |> Map.put("signature", encode_58(transaction.signature.signature))
           |> Map.put("public_key", encode_58(transaction.signature.public_key))
-      transaction.owner ->
-        base
-          |> Map.put("owner", encode_58(transaction.owner))
     end
   end
 

--- a/lib/daisy/storage.ex
+++ b/lib/daisy/storage.ex
@@ -7,11 +7,7 @@ defmodule Daisy.Storage do
   nature of `ipfs`, anyone can, even without having run the transactions.
   """
   use GenServer
-
-  @type root_hash :: String.t
-  @type data_hash :: String.t
-
-  @empty_data_proto <<8, 1>>
+  import Daisy.IPFS
 
   def start_link(opts \\ []) do
     host = Keyword.get(opts, :host, "localhost")
@@ -34,6 +30,8 @@ defmodule Daisy.Storage do
       client: client
     }}
   end
+
+  ### Server
 
   def handle_call(:new, _from, %{client: client}=state) do
     result = ipfs_new(client)
@@ -171,231 +169,49 @@ defmodule Daisy.Storage do
     {:reply, result, state}
   end
 
-  @spec ipfs_new(IPFS.Client.t) :: {:ok, root_hash} | {:error, any()}
-  defp ipfs_new(client) do
-    with {:ok, %IPFS.Client.PatchObject{hash: root_hash}} <- IPFS.Client.object_put(client, @empty_data_proto, true) do
-      {:ok, root_hash}
-    end
-  end
+  ### Client
 
-  @spec ipfs_put(IPFS.Client.t, root_hash, String.t, String.t) :: {:ok, root_hash} | {:error, any()}
-  defp ipfs_put(client, root_hash, path, data) do
-    # First, add the object
-    with {:ok, data_hash} <- ipfs_save(client, data) do
-      # Then, add to hash
-      ipfs_add_link(client, root_hash, path, data_hash)
-    end
-  end
-
-  @spec ipfs_add_link(IPFS.Client.t, root_hash, String.t, String.t) :: {:ok, root_hash} | {:error, any()}
-  defp ipfs_add_link(client, root_hash, path, data_hash) do
-    with {:ok, %IPFS.Client.PatchObject{hash: new_root_hash}} <- IPFS.Client.object_patch_add_link(client, root_hash, path, data_hash, true) do
-      {:ok, new_root_hash}
-    end
-  end
-
-  @spec ipfs_save(IPFS.Client.t, String.t) :: {:ok, root_hash} | {:error, any()}
-  defp ipfs_save(client, data) do
-    with {:ok, %IPFS.Client.PatchObject{hash: data_hash}} <- IPFS.Client.object_put(client, data, false) do
-      {:ok, data_hash}
-    end
-  end
-
-  @spec ipfs_put_all(IPFS.Client.t, root_hash, %{}) :: {:ok, binary()} | {:error, any()}
-  def ipfs_put_all(client, root_hash, values) do
-    Enum.reduce(values, {:ok, root_hash}, fn
-      {path, val}, {:ok, current_hash} when is_nil(val) or val == "" or val == %{} or val == {:link, ""} ->
-        # Skip blank nodes / maps
-        {:ok, current_hash}
-      {path, {:link, link}}, {:ok, current_hash} ->
-        # Directly put a link postfixed with _link
-        # TODO: Test
-        ipfs_add_link(client, current_hash, path <> "_link", link)
-      {path, data}, {:ok, current_hash} when is_binary(data) ->
-        # Put a simple value
-        ipfs_put(client, current_hash, path, data)
-      {path, values}, {:ok, current_hash} when is_map(values) ->
-        # Put a block of values
-        hash_result = case ipfs_get_hash(client, current_hash, path) do
-          {:ok, existing_root_hash} -> {:ok, existing_root_hash}
-          :not_found -> ipfs_new(client)
-          {:error, error} -> {:error, error}
-        end
-
-        with {:ok, hash_result_hash} <- hash_result do
-          with {:ok, values_root_hash} <- ipfs_put_all(client, hash_result_hash, values) do
-            # Link the new block to the current hash
-            ipfs_add_link(client, current_hash, path, values_root_hash)
-          end
-        end
-      _, {:error, error} -> {:error, error}
-    end)
-  end
-
-  @spec ipfs_get_all(IPFS.Client.t, root_hash) :: {:ok, %{}} | :not_found | {:error, any()}
-  def ipfs_get_all(client, root_hash) do
-    case do_ipfs_get_all(client, root_hash) do
-      {:ok, map} when is_map(map) ->
-        {:ok, map}
-      {:ok, data} when is_binary(data) ->
-        {:error, "expected root, got data: #{inspect data}"}
-      {:error, error} -> {:error, error}
-    end
-  end
-
-  @spec do_ipfs_get_all(IPFS.Client.t, root_hash) :: {:ok, %{} | String.t} | {:error, any()}
-  defp do_ipfs_get_all(client, root_hash) do
-    case ipfs_retrieve_all(client, root_hash) do
-      {:ok, data, links} when data == <<>> or data == @empty_data_proto ->
-        # This can probably be parallelized
-        Enum.reduce(links, {:ok, %{}}, fn
-          {name, hash}, {:ok, map} ->
-            # TODO: Maybe come up with a smarter system
-            if String.ends_with?(name, "_link") do
-              # This just stips the `_link` suffix and does not recurse
-              {:ok, Map.put(map, String.replace_suffix(name, "_link", ""), {:link, hash})}
-            else
-              with {:ok, result} = do_ipfs_get_all(client, hash) do
-                {:ok, Map.put(map, name, result)}
-              end
-            end
-          _, {:error, error} -> {:error, error}
-        end)
-      {:ok, data, []} ->
-        {:ok, data}
-      {:ok, data, links} -> {:error, "got both data and links, data=#{inspect data}, links=#{inspect links}"}
-      {:error, error} -> {:error, error}
-    end
-  end
-
-  @spec ipfs_retrieve(IPFS.Client.t, data_hash) :: {:ok, binary()} | {:error, any()}
-  defp ipfs_retrieve(client, data_hash) do
-    with {:ok, %IPFS.Client.Object{data: data}} <- IPFS.Client.object_get(client, data_hash) do
-      {:ok, data}
-    end
-  end
-
-  @spec ipfs_retrieve_all(IPFS.Client.t, data_hash) :: {:ok, String.t, [{String.t, data_hash}]} | {:error, any()}
-  defp ipfs_retrieve_all(client, data_hash) do
-    with {:ok, %IPFS.Client.Object{data: data, links: links}} <- IPFS.Client.object_get(client, data_hash) do
-      simple_links = for link <- links do
-        {link.name, link.hash}
-      end
-
-      {:ok, data, simple_links}
-    end
-  end
-
-  @spec ipfs_retrieve_proto(IPFS.Client.t, root_hash) :: {:ok, binary()} | {:error, any()}
-  defp ipfs_retrieve_proto(client, hash) do
-    with {:ok, proto} <- IPFS.Client.object_get_protobuf(client, hash) do
-      {:ok, proto}
-    end
-  end
-
-  @spec ipfs_get(IPFS.Client.t, root_hash, String.t) :: {:ok, String.t} | :not_found | {:error, any()}
-  defp ipfs_get(client, root_hash, path) do
-    with {:ok, data_hash} <- ipfs_get_hash(client, root_hash, path) do
-      with {:ok, data} <- ipfs_retrieve(client, data_hash) do
-        {:ok, data}
-      end
-    end
-  end
-
-  @spec ipfs_get_hash(IPFS.Client.t, root_hash, String.t) :: {:ok, String.t} | :not_found | {:error, any()}
-  defp ipfs_get_hash(client, root_hash, path) do
-    # Note: This might be slow since we need to walk entire path to find file
-    case walk_path(client, path, root_hash) do
-      {:ok, [], _found_path, _found_objects, _found_links, data_hash} ->
-        {:ok, data_hash}
-      {:ok, _looking_path, _found_path, _found_objects, _found_links, _data_hash} -> :not_found
-      els -> els
-    end
-  end
-
-  @spec ipfs_get_links(IPFS.Client.t, root_hash, String.t) :: {:ok, [{String.t, data_hash}]} | :not_found | {:error, any()}
-  defp ipfs_get_links(client, root_hash, path) do
-    # Note: This might be slow since we need to walk entire path to find file
-    case walk_path(client, path, root_hash) do
-      {:ok, [], _found_path, _found_objects, _found_links, data_hash} ->
-        with {:ok, _data, links} <- ipfs_retrieve_all(client, data_hash) do
-          {:ok, links}
-        end
-      {:ok, _looking_path, _found_path, _found_objects, _found_links, _data_hash} -> :not_found
-      els -> els
-    end
-  end
-
-  # Walks down a path as far as possible until it reaches the final path
-  # node or, if it fails, returns the last node on that path.
-  @spec walk_path(IPFS.Client.t, String.t, root_hash) :: {:ok, [String.t], [String.t], [IPFS.Client.Object.t], root_hash} | {:error, any()}
-  defp walk_path(client, path, root_hash) do
-    result = do_walk_path(client, Path.split(path), [], [], [], root_hash)
-
-    with {:ok, looking_path, found_path_reverse, found_objects, found_links, root_hash} <- result do
-      {:ok, looking_path, found_path_reverse |> Enum.reverse, found_objects, found_links, root_hash}
-    end
-  end
-
-  @spec do_walk_path(IPFS.Client.t, [String.t], [String.t], [IPFS.Client.Object.t], [String.t], root_hash) :: {:ok, [String.t], [String.t], [IPFS.Client.Object.t], root_hash} | {:error, any()}
-  defp do_walk_path(_client, [], found_path, found_objects, found_links, root_hash), do: {:ok, [], found_path, found_objects, found_links, root_hash}
-  defp do_walk_path(client, [sub_path|path]=looking_path, found_path, found_objects, found_links, root_hash) do
-    ipfs_result = IPFS.Client.object_get(client, root_hash)
-
-    with {:ok, %IPFS.Client.Object{links: links}=object} <- ipfs_result do
-      # Look for a link matching sub_path
-      link = Enum.find(links, fn link -> link.name == sub_path end)
-
-      # If we find it, recurse, otherwise, we're done
-      if link do
-        do_walk_path(client, path, [sub_path|found_path], [object|found_objects], [root_hash|found_links], link.hash)
-      else
-        {:ok, looking_path, found_path, found_objects, found_links, root_hash}
-      end
-    end
-  end
-
-  @spec new(identifier()) :: {:ok, root_hash} | {:error, any()}
+  @spec new(identifier()) :: {:ok, Daisy.IPFS.root_hash} | {:error, any()}
   def new(server) do
     GenServer.call(server, :new)
   end
 
-  @spec get(identifier(), root_hash, String.t) :: {:ok, String.t} | :not_found | {:error, any()}
+  @spec get(identifier(), Daisy.IPFS.root_hash, String.t) :: {:ok, String.t} | :not_found | {:error, any()}
   def get(server, root_hash, path) do
     GenServer.call(server, {:get, root_hash, clean(path)})
   end
 
-  @spec get_all(identifier(), root_hash, String.t) :: {:ok, %{}} | {:error, any()}
+  @spec get_all(identifier(), Daisy.IPFS.root_hash, String.t) :: {:ok, %{}} | {:error, any()}
   def get_all(server, root_hash, path \\ "") do
     GenServer.call(server, {:get_all, root_hash, clean(path)})
   end
 
-  @spec get_hash(identifier(), root_hash, String.t) :: {:ok, String.t} | :not_found | {:error, any()}
+  @spec get_hash(identifier(), Daisy.IPFS.root_hash, String.t) :: {:ok, String.t} | :not_found | {:error, any()}
   def get_hash(server, root_hash, path) do
     GenServer.call(server, {:get_hash, root_hash, clean(path)})
   end
 
-  @spec proof(identifier(), root_hash, String.t) :: :ok | :not_found | {:error, any()}
+  @spec proof(identifier(), Daisy.IPFS.root_hash, String.t) :: :ok | :not_found | {:error, any()}
   def proof(server, root_hash, path) do
     GenServer.call(server, {:proof, root_hash, clean(path)})
   end
 
-  @spec put(identifier(), root_hash, String.t, binary()) :: {:ok, root_hash} | {:error, any()}
+  @spec put(identifier(), Daisy.IPFS.root_hash, String.t, binary()) :: {:ok, Daisy.IPFS.root_hash} | {:error, any()}
   def put(server, root_hash, path, value) do
     GenServer.call(server, {:put, root_hash, clean(path), value})
   end
 
-  @spec put_all(identifier(), root_hash, [{String.t, binary()}]) :: {:ok, root_hash} | {:error, any()}
+  @spec put_all(identifier(), Daisy.IPFS.root_hash, [{String.t, binary()}]) :: {:ok, Daisy.IPFS.root_hash} | {:error, any()}
   def put_all(server, root_hash, values) do
     GenServer.call(server, {:put_all, root_hash, values})
   end
 
-  @spec put(identifier(), root_hash, String.t, binary()) :: {:ok, root_hash} | :file_exists | {:error, any()}
+  @spec put(identifier(), Daisy.IPFS.root_hash, String.t, binary()) :: {:ok, Daisy.IPFS.root_hash} | :file_exists | {:error, any()}
   def put_new(server, root_hash, path, value) do
     GenServer.call(server, {:put_new, root_hash, clean(path), value})
   end
 
-  @spec update(identifier(), root_hash, String.t, (String.t -> String.t), [default: String.t, run_update_fn_on_default: boolean()]) :: {:ok, root_hash} | {:error, any()}
+  @spec update(identifier(), Daisy.IPFS.root_hash, String.t, (String.t -> String.t), [default: String.t, run_update_fn_on_default: boolean()]) :: {:ok, Daisy.IPFS.root_hash} | {:error, any()}
   def update(server, root_hash, path, update_fn, opts \\ []) do
     default = Keyword.get(opts, :default, "")
     run_update_fn_on_default = Keyword.get(opts, :run_update_fn_on_default, false)
@@ -403,19 +219,19 @@ defmodule Daisy.Storage do
     GenServer.call(server, {:update, root_hash, clean(path), update_fn, default, run_update_fn_on_default})
   end
 
-  @spec ls(identifier(), root_hash, String.t) :: {:ok, [{String.t, data_hash}]} | {:error, any()}
+  @spec ls(identifier(), Daisy.IPFS.root_hash, String.t) :: {:ok, [{String.t, Daisy.IPFS.data_hash}]} | {:error, any()}
   def ls(server, root_hash, path) do
     GenServer.call(server, {:ls, root_hash, clean(path)})
   end
 
   # TODO: Test
-  @spec save(identifier(), binary()) :: {:ok, data_hash} | {:error, any()}
+  @spec save(identifier(), binary()) :: {:ok, Daisy.IPFS.data_hash} | {:error, any()}
   def save(server, data) do
     GenServer.call(server, {:save, data})
   end
 
   # TODO: Test
-  @spec retrieve(identifier(), data_hash) :: {:ok, binary()} | {:error, any()}
+  @spec retrieve(identifier(), Daisy.IPFS.data_hash) :: {:ok, binary()} | {:error, any()}
   def retrieve(server, data_hash) do
     GenServer.call(server, {:retrieve, data_hash})
   end

--- a/lib/daisy/tracker/tracker.ex
+++ b/lib/daisy/tracker/tracker.ex
@@ -101,7 +101,7 @@ defmodule Daisy.Tracker do
   defp server_mine_block(block, storage_pid, runner) do
     # First, finalize the block
     with {:ok, finalized_block, final_block_hash} <- Daisy.Block.Processor.process_and_save_block(block, storage_pid, runner) do
-      Logger.debug("[#{__MODULE__}] Minted block #{inspect finalized_block}")
+      Logger.debug("[#{__MODULE__}] Minted block #{inspect finalized_block} (/ipfs/#{final_block_hash})")
       # Finally, start a new block
       with {:ok, new_block} <- Daisy.Block.Builder.new_block(final_block_hash, storage_pid, []) do
         {:ok, final_block_hash, new_block}

--- a/lib/mix/tasks/daisy.leader.ex
+++ b/lib/mix/tasks/daisy.leader.ex
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.Daisy.Leader do
     run_api = Keyword.get(parsed, :api, false)
     api_port = Keyword.get(parsed, :port, nil)
 
-    Application.put_env(:daisy, :api, run_api, persistent: true)
+    Application.put_env(:daisy, :run_api, run_api, persistent: true)
     Application.put_env(:daisy, :run_leader, true, persistent: true)
 
     if run_api && api_port do

--- a/script/ipfs/key_gen
+++ b/script/ipfs/key_gen
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-if [ "$#" -lt 1 ]; then
+set -eo pipefail
+
+if [ ! "$#" -eq 1 ]; then
 	printf "generates a new ipfs key\n\nusage:\n\tscript/ipfs/new_key <key_name>\n\n"
 	exit 1
 fi

--- a/script/keys/new
+++ b/script/keys/new
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eo pipefail
+
+if [ ! "$#" -eq 0 ]; then
+	printf "generates a daisy keys\n\nusage:\n\tscript/keys/new\n\n"
+	exit 1
+fi
+
+daisy_folder=~/.daisy
+
+echo "Generating keys to $daisy_folder"
+
+mkdir -p $daisy_folder
+
+/usr/local/opt/openssl/bin/openssl \
+	ecparam -genkey \
+	-name secp256k1 \
+	-noout \
+	-out $daisy_folder/private_key.pem
+
+/usr/local/opt/openssl/bin/openssl \
+	ec \
+	-in $daisy_folder/private_key.pem \
+	-pubout \
+	-outform DER \
+	-out $daisy_folder/public_key.der
+

--- a/script/trx
+++ b/script/trx
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+if [ ! "$#" -eq 1 ]; then
+	printf "runs a daisy transaction\n\nusage:\n\tscript/trx <cmd>/<arg0>/<arg1>/...\n\n"
+	exit 1
+fi
+
+cmd="$1"
+
+host="http://localhost:2335"
+daisy_folder=~/.daisy
+public_key_file=$daisy_folder/public_key.der
+private_key_file=$daisy_folder/private_key.pem
+
+if [ ! -f $public_key_file ]; then
+	printf "cannot find public key at $public_key_file\n\nplease run 'script/keys/new'\n\n"
+	exit 1
+fi
+
+if [ ! -f $private_key_file ]; then
+	printf "cannot find private key at $private_key_file\n\nplease run 'script/keys/new'\n\n"
+	exit 1
+fi
+
+public_key="$(cat $public_key_file | base64)"
+
+prepare="$(curl "http://localhost:2335/prepare/$cmd" -s)"
+
+signature="$(curl $host/prepare/$cmd -s \
+			| base64 -D \
+			| /usr/local/opt/openssl/bin/openssl dgst -sha256 -sign $private_key_file \
+			| base64)"
+
+curl -X POST "$host/run/$cmd" --data-urlencode "signature=$signature" --data-urlencode "public_key=$public_key"

--- a/test/daisy/serializer/json_serializer_test.exs
+++ b/test/daisy/serializer/json_serializer_test.exs
@@ -1,5 +1,0 @@
-defmodule Daisy.Serializer.JSONSerializerTest do
-  use ExUnit.Case, async: true
-  doctest Daisy.Serializer.JSONSerializer
-
-end

--- a/test/daisy/serializer_test.exs
+++ b/test/daisy/serializer_test.exs
@@ -1,0 +1,5 @@
+defmodule Daisy.SerializerTest do
+  use ExUnit.Case, async: true
+  doctest Daisy.Serializer
+
+end


### PR DESCRIPTION
This patch adds a simple link system that let's us now store all data via IPFS file system links (whereas we used to just stoe the hash of other IPFS trees, we now store them as proper links). This seemingless small change makes it very easy to view and understand the entire block just from looking at IPFS. We currently just label such links as "<name>_link" so that we know not to fully load them  (and instead, to load that data on demand as needed).

We also add scripts to execute transactions properly, add a deterministic random module, and start to get followers close to matching and keeping up to the date with leaders.